### PR TITLE
Introduce new SUMO instance class based on `libsumo`

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install SUMO
-      run: sudo apt-get install sumo
+      run: sudo apt-get install sumo sumo-tools
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,9 +1,9 @@
-name: coverage
+name: Coverage
 
 on: [push]
 
 jobs:
-  build:
+  coverage:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,5 +23,6 @@ jobs:
         pip install -e '.[test]'
     - name: Test with coverage
       run: |
+        export NO_LIBSUMO=1
         coverage run --source=muve --branch -m pytest tests/
         coverage report --fail-under=100 --skip-empty --skip-covered -m

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,8 +16,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install SUMO
-      run: sudo apt-get install sumo sumo-tools
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint (mypy and flake8)
 on: [push]
 
 jobs:
-  build:
+  lint:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install SUMO
-      run: sudo apt-get install sumo
+      run: sudo apt-get install sumo sumo-tools
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
-name: pytest Tests
+name: Tests (without sumolib)
 
 on: [push]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
-name: Tests (without sumolib)
+name: Tests (pytest without sumolib)
 
 on: [push]
 
 jobs:
-  test:
+  pytest-no-sumolib:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,4 +23,5 @@ jobs:
         pip install -e '.[test]'
     - name: Test with pytest
       run: |
+        export NO_LIBSUMO=1
         pytest tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install SUMO
-      run: sudo apt-get install sumo sumo-tools
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 # SUMO Server
 Server for simulating traffic and relaying traffic information programatically through SUMO.
 
-The server interfaces with SUMO through a TCP socket.
-
 ### Installation
 This project requires Python 3.8+ and an existing [SUMO installation](https://sumo.dlr.de/docs/Downloads.php) with Python bindings.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Server for simulating traffic and relaying traffic information programatically through SUMO.
 
 ### Installation
-This project requires Python 3.8+ and an existing [SUMO installation](https://sumo.dlr.de/docs/Downloads.php) with Python bindings.
+This project requires Python 3.8+ and an existing [SUMO installation](https://sumo.dlr.de/docs/Downloads.php) with Python bindings and `sumo-tools`.
 
 #### Development
 1. Clone this repository:

--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@ pip install -e '.[lint, test, tox]'
 
 6. Test that everything works correctly:
 ```bash
-tox -p
+tox -p --sitepackages
 ```

--- a/muve/sumo_server/sumo/instances.py
+++ b/muve/sumo_server/sumo/instances.py
@@ -9,9 +9,13 @@ import abc
 import ipaddress
 import pathlib
 import subprocess  # noqa: S404, security
-from typing import Final, List, Optional, Union
+from typing import ClassVar, Final, List, Optional, TypeVar, Union
+
+import libsumo  # type: ignore
 
 from muve.sumo_server.sumo.tcp import SumoTcpConnection
+
+StatusGuardedFuncType = TypeVar("StatusGuardedFuncType")
 
 
 class SumoInstance(abc.ABC):
@@ -20,7 +24,13 @@ class SumoInstance(abc.ABC):
     This class cannot be instantiated, but should be extended to actually implement this interface.
     """
 
+    class SumoStatusError(Exception):
+        """Raised when a the status of the SUMO instance is incompatible with the operation called."""
+
+    _CONFIGURATION_FLAG: Final[str] = "-c"
+
     _config: pathlib.Path
+    _is_started: bool
 
     def __init__(self, *, config: pathlib.Path) -> None:
         """Initialize the abstract SUMO instance with a SUMO configuration.
@@ -35,6 +45,7 @@ class SumoInstance(abc.ABC):
             raise ValueError(f"provided configuration file {config} does not exist")
 
         self._config = config
+        self._is_started = False
 
     @property
     def config(self) -> pathlib.Path:
@@ -57,23 +68,108 @@ class SumoInstance(abc.ABC):
         """Stop the interaction with SUMO and clean up."""
 
 
+class LocalLibSumoInstance(SumoInstance):
+    """Manages interactions with `libsumo`_ to provide an interface to SUMO.
+
+    Do not manually instantiate this class, use
+    :meth:`~muve.sumo_server.sumo.manager.SumoInstanceManager.create_instance` instead.
+
+    .. _`libsumo`: https://sumo.dlr.de/docs/Libsumo.html
+    """
+
+    class SumoLibError(Exception):
+        """Raised when something goes wrong with our interface to SUMO, `libsumo`."""
+
+    _exists_started: ClassVar[bool] = False
+
+    def __init__(self, *, config: pathlib.Path) -> None:
+        """Initialize the `libsumo` SUMO instance with a SUMO configuration.
+
+        :param config: Path to the `sumocfg`_ configuration file.
+
+        :raises ValueError: The provided configuration path does not exist.
+
+        .. _`sumocfg`: https://sumo.dlr.de/docs/Tutorials/Hello_SUMO.html
+        """
+        try:
+            super().__init__(config=config)
+        except ValueError:
+            raise
+
+    def start(self) -> None:
+        """Start the interaction with SUMO.
+
+        :raises SumoStatusError: This instance is already running.
+        :raises SumoLibError: Cannot start the interaction with the SUMO simulation.
+        """
+        if self._is_started:
+            raise self.SumoStatusError("this SUMO instance is already started")
+        if LocalLibSumoInstance._exists_started:
+            raise self.SumoLibError("`libsumo` only supports one simulation running at a time")
+
+        try:
+            # The first argument (in the list) is typically the SUMO executable
+            # but using libsumo do not need to provide it.
+            # NOTE: consider using the `traceFile` argument here.
+            libsumo.start(["", self._CONFIGURATION_FLAG, str(self.config)])  # type: ignore
+        except libsumo.TraCIException as e:  # type: ignore
+            self._is_started = False
+            raise self.SumoLibError(e)  # type: ignore
+
+        self._is_started = True
+        LocalLibSumoInstance._exists_started = True
+
+    def step(self) -> None:
+        """Step the SUMO simulation.
+
+        :raises SumoStatusError: This instance is not running.
+        :raises SumoLibError: Stepping caused an exception with the SUMO library.
+        """
+        if not self._is_started:
+            raise self.SumoStatusError("this SUMO instance is not started")
+
+        try:
+            # NOTE: this returns subscription values, consider parsing them.
+            libsumo.simulation.step()  # type: ignore
+        except libsumo.TraCIException as e:  # type: ignore
+            self.stop()
+            raise self.SumoLibError(e)  # type: ignore
+
+    def stop(self) -> None:
+        """Stop the interaction with SUMO which stops the simulation.
+
+        :raises SumoStatusError: This instance is not running.
+        :raises SumoLibError: Stopping caused an exception with the SUMO library.
+        """
+        if not self._is_started:
+            raise self.SumoStatusError("this SUMO instance is not started")
+
+        try:
+            libsumo.close()  # type: ignore
+        except libsumo.TraCIException as e:  # type: ignore
+            raise self.SumoLibError(e)  # type: ignore
+        finally:
+            self._is_started = False
+            LocalLibSumoInstance._exists_started = False
+
+
 class LocalTcpSumoInstance(SumoInstance):
     """Manages a single local SUMO process and the related TCP socket connection for communication.
 
-    Do not manually instantiate this class, use :meth:`~muve.sumo_server.sumo.manager.create_instance` instead.
+    Do not manually instantiate this class, use
+    :meth:`~muve.sumo_server.sumo.manager.SumoInstanceManager.create_instance` instead.
     """
-
-    LOCAL_HOST: Final[ipaddress.IPv4Address] = ipaddress.IPv4Address("127.0.0.1")
-    _CONFIGURATION_FLAG: Final[str] = "-c"
-    _PORT_NUMBER_FLAG: Final[str] = "--remote-port"
-    _NUM_CLIENTS_FLAG: Final[str] = "--num-clients"
-    _NUM_CLIENTS: Final[int] = 1
 
     class SumoProcessError(Exception):
         """Raised when something goes wrong with the SUMO subprocess."""
 
     class SumoConnectionError(Exception):
         """Raised when something goes wrong with the SUMO connection."""
+
+    LOCAL_HOST: Final[ipaddress.IPv4Address] = ipaddress.IPv4Address("127.0.0.1")
+    _PORT_NUMBER_FLAG: Final[str] = "--remote-port"
+    _NUM_CLIENTS_FLAG: Final[str] = "--num-clients"
+    _NUM_CLIENTS: Final[int] = 1
 
     _executable: pathlib.Path
     _port: int
@@ -84,15 +180,17 @@ class LocalTcpSumoInstance(SumoInstance):
         """Initialize a SUMO instance manager.
 
         :param config: Path to the `sumocfg`_ configuration file.
-        :param executable: Path to the base `sumo`_ executable.
+        :param executable: Path to the base SUMO executable.
         :param port: Port number to spawn and connect to the SUMO instance on.
 
         :raises ValueError: One or more of the provided paths does not exist.
 
         .. _`sumocfg`: https://sumo.dlr.de/docs/Tutorials/Hello_SUMO.html
-        .. _`sumo`: https://sumo.dlr.de/docs/sumo.html
         """
-        super().__init__(config=config)
+        try:
+            super().__init__(config=config)
+        except ValueError:
+            raise
 
         if not executable.exists():
             raise ValueError(f"provided executable file {executable} does not exist")
@@ -181,7 +279,7 @@ class LocalTcpSumoInstance(SumoInstance):
         .. _`subprocess exceptions documentation`: https://docs.python.org/3/library/subprocess.html#exceptions
         """
         args: List[Union[str, pathlib.Path]] = [
-            self.executable,
+            str(self.executable),
             self._CONFIGURATION_FLAG,
             str(self.config),
             self._PORT_NUMBER_FLAG,

--- a/muve/sumo_server/sumo/instances.py
+++ b/muve/sumo_server/sumo/instances.py
@@ -16,7 +16,7 @@ from unittest import mock
 
 # libsumo refuses to install quickly for CI/CD unittests, if this environment variable is False just don't use it.
 # The mocks in tests should take care of actually letting libsumo be called (mocked).
-if not int(os.getenv("NO_LIBSUMO", False)):
+if not int(os.getenv("NO_LIBSUMO", False)):  # pragma: nocover
     import libsumo  # type: ignore
 else:
     libsumo = mock.MagicMock()

--- a/muve/sumo_server/sumo/instances.py
+++ b/muve/sumo_server/sumo/instances.py
@@ -143,7 +143,36 @@ class LocalTcpSumoInstance(SumoInstance):
             raise self.SumoConnectionError("SUMO connection is not established")
         return self._connection
 
-    def spawn(self) -> None:
+    def start(self) -> None:
+        """Start the interaction with SUMO by spawning a SUMO subprocess and connecting to it.
+
+        This effectively starts the simulation; however, it will not run. See :meth:`~.step` to run the simulation.
+
+        :raises SumoStatusError: This instance is already running.
+        """
+        if self._is_started:
+            raise self.SumoStatusError("this SUMO instance is already started")
+
+        self._spawn()
+        self._connect()
+
+        self._is_started = True
+
+    def step(self) -> None:
+        """Step the SUMO simulation.
+
+        :raises NotImplementedError: Not implemented.
+        """
+        raise NotImplementedError
+
+    def stop(self) -> None:
+        """Stop the interaction with SUMO, stop the simulation, and close the connection.
+
+        :raises NotImplementedError: Not implemented.
+        """
+        raise NotImplementedError
+
+    def _spawn(self) -> None:
         """Spawn the SUMO process.
 
         :raises SumoProcessError: Something went wrong with creating the SUMO subprocess. The error is more
@@ -166,29 +195,7 @@ class LocalTcpSumoInstance(SumoInstance):
         except subprocess.SubprocessError as e:
             raise self.SumoProcessError(e)
 
-    def connect(self) -> None:
+    def _connect(self) -> None:
         """Connect to the SUMO instance over a TCP socket."""
         self._connection = SumoTcpConnection(self.LOCAL_HOST, self.port)
         self._connection.connect()
-
-    def start(self) -> None:
-        """Start the interaction with SUMO by spawning a SUMO subprocess and connecting to it.
-
-        This effectively starts the simulation; however, it will not run. See :meth:`~.step` to run the simulation.
-        """
-        self.spawn()
-        self.connect()
-
-    def step(self) -> None:
-        """Step the SUMO simulation.
-
-        :raises NotImplementedError: Not implemented.
-        """
-        raise NotImplementedError
-
-    def stop(self) -> None:
-        """Stop the interaction with SUMO, stop the simulation, and close the connection.
-
-        :raises NotImplementedError: Not implemented.
-        """
-        raise NotImplementedError

--- a/setup.cfg
+++ b/setup.cfg
@@ -112,6 +112,7 @@ rst-roles =
   func,
   meth,
   mod,
+  class,
 
 [mypy]
 files = muve/**/*.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -144,3 +144,6 @@ allow_redefinition = false
 implicit_reexport = false
 strict_equality = true
 incremental = true
+
+[isort]
+line_length = 119

--- a/tests/sumo_server/sumo/test_instances.py
+++ b/tests/sumo_server/sumo/test_instances.py
@@ -6,7 +6,6 @@ import subprocess  # noqa: S404, security
 from typing import Final
 from unittest import mock
 
-import libsumo  # type: ignore
 import pytest
 
 from muve.sumo_server.sumo.instances import LocalLibSumoInstance, LocalTcpSumoInstance, SumoInstance
@@ -159,160 +158,137 @@ class TestLocalTcpSumoInstance(TestSumoInstance):
             instance.stop()
 
 
+@mock.patch.object(LocalLibSumoInstance, "_libsumo")
 class TestLocalLibSumoInstance:
     def init_instance(self) -> LocalLibSumoInstance:
         LocalLibSumoInstance._exists_started = False
         config = TestSumoInstance.FAKE_PATH
         return LocalLibSumoInstance(config=config)
 
-    def test_init_succeeds(self) -> None:
+    def test_init_succeeds(self, mock_libsumo: mock.MagicMock) -> None:
         self.init_instance()
 
-    def test_init_fails_when_no_config(self) -> None:
+    def test_init_fails_when_no_config(self, mock_libsumo: mock.MagicMock) -> None:
         config = TestSumoInstance.NONEXISTENT_PATH
 
         with pytest.raises(ValueError, match="config"):
             LocalLibSumoInstance(config=config)
 
-    def test_start_succeeds(self) -> None:
+    def test_start_succeeds(self, mock_libsumo: mock.MagicMock) -> None:
         instance = self.init_instance()
 
-        with mock.patch("libsumo.start") as mock_libsumo_start:
-            instance.start()
-            args = [
-                "",
-                LocalTcpSumoInstance._CONFIGURATION_FLAG,
-                str(TestSumoInstance.FAKE_PATH),
-            ]
-            mock_libsumo_start.assert_called_once_with(args)
+        instance.start()
+        args = [
+            "",
+            LocalTcpSumoInstance._CONFIGURATION_FLAG,
+            str(TestSumoInstance.FAKE_PATH),
+        ]
 
-    def test_start_fails_when_already_started(self) -> None:
+        mock_libsumo.start.assert_called_once_with(args)
+
+    def test_start_fails_when_already_started(self, mock_libsumo: mock.MagicMock) -> None:
         instance = self.init_instance()
 
-        with mock.patch("libsumo.start") as mock_libsumo_start:
+        instance.start()
+
+        with pytest.raises(LocalLibSumoInstance.SumoStatusError, match="already started"):
             instance.start()
 
-            with pytest.raises(LocalLibSumoInstance.SumoStatusError, match="already started"):
-                instance.start()
+        mock_libsumo.start.assert_called_once()
 
-            mock_libsumo_start.assert_called_once()
-
-    def test_start_fails_when_other_started(self) -> None:
+    def test_start_fails_when_other_started(self, mock_libsumo: mock.MagicMock) -> None:
         instance1 = self.init_instance()
         instance2 = self.init_instance()
 
-        with mock.patch("libsumo.start") as mock_libsumo_start:
-            instance1.start()
+        instance1.start()
 
-            with pytest.raises(LocalLibSumoInstance.SumoLibError, match="one simulation"):
-                instance2.start()
+        with pytest.raises(LocalLibSumoInstance.SumoLibError, match="one simulation"):
+            instance2.start()
 
-            mock_libsumo_start.assert_called_once()
+        mock_libsumo.start.assert_called_once()
 
-    def test_start_fails_when_lib_errors(self) -> None:
+    def test_start_fails_when_lib_errors(self, mock_libsumo: mock.MagicMock) -> None:
         instance = self.init_instance()
+        mock_libsumo.TraCIException = Exception
+        mock_libsumo.start.side_effect = mock_libsumo.TraCIException("")
 
-        with mock.patch("libsumo.start") as mock_libsumo_start:
-            mock_libsumo_start.side_effect = libsumo.TraCIException("")
-
-            with pytest.raises(LocalLibSumoInstance.SumoLibError):
-                instance.start()
-
-            mock_libsumo_start.assert_called_once()
-
-    def test_step_succeeds(self) -> None:
-        instance = self.init_instance()
-
-        with mock.patch("libsumo.start"):
+        with pytest.raises(LocalLibSumoInstance.SumoLibError):
             instance.start()
 
-        with mock.patch("libsumo.simulation.step") as mock_libsumo_step:
+        mock_libsumo.start.assert_called_once()
+
+    def test_step_succeeds(self, mock_libsumo: mock.MagicMock) -> None:
+        instance = self.init_instance()
+        instance.start()
+
+        instance.step()
+
+        mock_libsumo.simulation.step.assert_called_once()
+
+    def test_step_fails_when_not_started(self, mock_libsumo: mock.MagicMock) -> None:
+        instance = self.init_instance()
+
+        with pytest.raises(LocalLibSumoInstance.SumoStatusError, match="not started"):
             instance.step()
 
-            mock_libsumo_step.assert_called_once()
+        mock_libsumo.simulation.step.assert_not_called()
 
-    def test_step_fails_when_not_started(self) -> None:
+    def test_step_fails_and_stops_when_lib_errors(self, mock_libsumo: mock.MagicMock) -> None:
         instance = self.init_instance()
+        instance.start()
 
-        with mock.patch("libsumo.simulation.step") as mock_libsumo_step:
-            with pytest.raises(LocalLibSumoInstance.SumoStatusError, match="not started"):
-                instance.step()
-
-            mock_libsumo_step.assert_not_called()
-
-    def test_step_fails_and_stops_when_lib_errors(self) -> None:
-        instance = self.init_instance()
-
-        with mock.patch("libsumo.start"):
-            instance.start()
-
-        with mock.patch("libsumo.simulation.step") as mock_libsumo_step, mock.patch.object(
-            instance,
-            "stop",
-        ) as stop_mock:
-            mock_libsumo_step.side_effect = libsumo.TraCIException("")
+        with mock.patch.object(instance, "stop") as stop_mock:
+            mock_libsumo.TraCIException = Exception
+            mock_libsumo.simulation.step.side_effect = mock_libsumo.TraCIException("")
 
             with pytest.raises(LocalLibSumoInstance.SumoLibError):
                 instance.step()
 
-            mock_libsumo_step.assert_called_once()
+            mock_libsumo.simulation.step.assert_called_once()
             stop_mock.assert_called_once()
 
-    def test_stop_succeeds(self) -> None:
+    def test_stop_succeeds(self, mock_libsumo: mock.MagicMock) -> None:
+        instance = self.init_instance()
+        instance.start()
+
+        instance.stop()
+
+        mock_libsumo.close.assert_called_once()
+
+    def test_stop_fails_when_not_started(self, mock_libsumo: mock.MagicMock) -> None:
         instance = self.init_instance()
 
-        with mock.patch("libsumo.start"):
-            instance.start()
-
-        with mock.patch("libsumo.simulation.close") as mock_libsumo_close:
+        with pytest.raises(LocalLibSumoInstance.SumoStatusError, match="not started"):
             instance.stop()
 
-            mock_libsumo_close.assert_called_once()
+        mock_libsumo.close.assert_not_called()
 
-    def test_stop_fails_when_not_started(self) -> None:
+    def test_stop_fails_when_lib_errors(self, mock_libsumo: mock.MagicMock) -> None:
         instance = self.init_instance()
+        instance.start()
 
-        with mock.patch("libsumo.simulation.close") as mock_libsumo_close:
-            with pytest.raises(LocalLibSumoInstance.SumoStatusError, match="not started"):
-                instance.stop()
+        mock_libsumo.TraCIException = Exception
+        mock_libsumo.close.side_effect = mock_libsumo.TraCIException("")
 
-            mock_libsumo_close.assert_not_called()
+        with pytest.raises(LocalLibSumoInstance.SumoLibError):
+            instance.stop()
 
-    def test_stop_fails_when_lib_errors(self) -> None:
-        instance = self.init_instance()
+        mock_libsumo.close.assert_called_once()
 
-        with mock.patch("libsumo.start"):
-            instance.start()
-
-        with mock.patch("libsumo.simulation.close") as mock_libsumo_close:
-            mock_libsumo_close.side_effect = libsumo.TraCIException("")
-
-            with pytest.raises(LocalLibSumoInstance.SumoLibError):
-                instance.stop()
-
-            mock_libsumo_close.assert_called_once()
-
-    def test_start_step_stop_repeated_succeeds(self) -> None:
+    def test_start_step_stop_repeated_succeeds(self, mock_libsumo: mock.MagicMock) -> None:
         instance = self.init_instance()
 
         for _ in range(3):
-            with mock.patch("libsumo.start"):
-                instance.start()
-            with mock.patch("libsumo.simulation.step"):
-                instance.step()
-            with mock.patch("libsumo.simulation.close"):
-                instance.stop()
-
-    def test_start_step_stop_step_fails(self) -> None:
-        instance = self.init_instance()
-
-        with mock.patch("libsumo.start"):
             instance.start()
-        with mock.patch("libsumo.simulation.step"):
             instance.step()
-        with mock.patch("libsumo.simulation.close"):
             instance.stop()
 
-        with mock.patch("libsumo.simulation.step"):
-            with pytest.raises(LocalLibSumoInstance.SumoStatusError, match="not started"):
-                instance.step()
+    def test_start_step_stop_step_fails(self, mock_libsumo: mock.MagicMock) -> None:
+        instance = self.init_instance()
+
+        instance.start()
+        instance.step()
+        instance.stop()
+
+        with pytest.raises(LocalLibSumoInstance.SumoStatusError, match="not started"):
+            instance.step()

--- a/tests/sumo_server/sumo/test_manager.py
+++ b/tests/sumo_server/sumo/test_manager.py
@@ -6,108 +6,169 @@ from unittest import mock
 
 import pytest
 
+from muve.sumo_server.sumo.instances import LocalLibSumoInstance, LocalTcpSumoInstance
 from muve.sumo_server.sumo.manager import SumoInstanceManager
 
 
-@mock.patch("muve.sumo_server.sumo.manager.LocalTcpSumoInstance")
 class TestSumoInstanceManager:
-    FAKE_PATH: Final[pathlib.Path] = pathlib.Path(__file__).absolute()
-    PORT_NUMBER: Final[int] = 9800
+    @mock.patch("muve.sumo_server.sumo.manager.LocalTcpSumoInstance", autospec=True)
+    class TestLocalTcpInstance:
+        """Tests functionality relating to local TCP SUMO instances."""
 
-    def test_create_instance_succeeds(self, mocked_instance: mock.MagicMock) -> None:
-        name = inspect.stack()[0][3]
+        FAKE_PATH: Final[pathlib.Path] = pathlib.Path(__file__).absolute()
+        PORT_NUMBER: Final[int] = 9800
 
-        SumoInstanceManager.create_instance(name, config=self.FAKE_PATH)
+        def test_create_local_tcp_instance_succeeds(self, mocked_instance: mock.MagicMock) -> None:
+            name = inspect.stack()[0][3]
 
-        mocked_instance.assert_called_once_with(
-            config=self.FAKE_PATH,
-            executable=mock.ANY,
-            port=mock.ANY,
-        )
+            instance = SumoInstanceManager.create_local_tcp_instance(name, config=self.FAKE_PATH)
 
-    def test_create_instance_succeeds_and_correct_port(self, mocked_instance: mock.MagicMock) -> None:
-        name = inspect.stack()[0][3]
+            assert isinstance(instance, LocalTcpSumoInstance)
+            mocked_instance.assert_called_once_with(
+                config=self.FAKE_PATH,
+                executable=mock.ANY,
+                port=mock.ANY,
+            )
 
-        SumoInstanceManager.create_instance(name, config=self.FAKE_PATH)
+        def test_create_local_tcp_instance_succeeds_and_correct_port(self, mocked_instance: mock.MagicMock) -> None:
+            name = inspect.stack()[0][3]
 
-        mocked_instance.assert_called_once_with(
-            config=self.FAKE_PATH,
-            executable=mock.ANY,
-            port=SumoInstanceManager._current_port_number - 1,
-        )
+            instance = SumoInstanceManager.create_local_tcp_instance(name, config=self.FAKE_PATH)
 
-    def test_create_instance_succeeds_with_executable_path(self, mocked_instance: mock.MagicMock) -> None:
-        name = inspect.stack()[0][3]
+            assert isinstance(instance, LocalTcpSumoInstance)
+            mocked_instance.assert_called_once_with(
+                config=self.FAKE_PATH,
+                executable=mock.ANY,
+                port=SumoInstanceManager._current_port_number - 1,
+            )
 
-        SumoInstanceManager.create_instance(name, config=self.FAKE_PATH, executable=self.FAKE_PATH)
+        def test_create_local_tcp_instance_succeeds_with_executable_path(
+            self,
+            mocked_instance: mock.MagicMock,
+        ) -> None:
+            name = inspect.stack()[0][3]
 
-        mocked_instance.assert_called_once_with(
-            config=self.FAKE_PATH,
-            executable=self.FAKE_PATH,
-            port=mock.ANY,
-        )
-
-    def test_create_instance_succeeds_with_custom_port_number(self, mocked_instance: mock.MagicMock) -> None:
-        name = inspect.stack()[0][3]
-        port = self.PORT_NUMBER
-
-        SumoInstanceManager.create_instance(name, config=self.FAKE_PATH, port=port)
-
-        mocked_instance.assert_called_once_with(
-            config=self.FAKE_PATH,
-            executable=mock.ANY,
-            port=port,
-        )
-
-    def test_create_instance_fails_when_nonexistent_executable(self, mocked_instance: mock.MagicMock) -> None:
-        name = inspect.stack()[0][3]
-        port = self.PORT_NUMBER
-        default_sumo_command = SumoInstanceManager._DEFAULT_SUMO_COMMAND_NAME
-
-        SumoInstanceManager._DEFAULT_SUMO_COMMAND_NAME = "command_does_not_exist"
-        with pytest.raises(SumoInstanceManager.SumoExecutableNotFound, match="sumo"):
-            SumoInstanceManager.create_instance(
+            instance = SumoInstanceManager.create_local_tcp_instance(
                 name,
                 config=self.FAKE_PATH,
+                executable=self.FAKE_PATH,
+            )
+
+            assert isinstance(instance, LocalTcpSumoInstance)
+            mocked_instance.assert_called_once_with(
+                config=self.FAKE_PATH,
+                executable=self.FAKE_PATH,
+                port=mock.ANY,
+            )
+
+        def test_create_local_tcp_instance_succeeds_with_custom_port_number(
+            self,
+            mocked_instance: mock.MagicMock,
+        ) -> None:
+            name = inspect.stack()[0][3]
+            port = self.PORT_NUMBER
+
+            instance = SumoInstanceManager.create_local_tcp_instance(name, config=self.FAKE_PATH, port=port)
+
+            assert isinstance(instance, LocalTcpSumoInstance)
+            mocked_instance.assert_called_once_with(
+                config=self.FAKE_PATH,
+                executable=mock.ANY,
                 port=port,
             )
 
-        SumoInstanceManager._DEFAULT_SUMO_COMMAND_NAME = default_sumo_command
-        mocked_instance.assert_not_called()
+        def test_create_local_tcp_instance_fails_when_nonexistent_executable(
+            self,
+            mocked_instance: mock.MagicMock,
+        ) -> None:
+            name = inspect.stack()[0][3]
+            port = self.PORT_NUMBER
+            default_sumo_command = SumoInstanceManager._DEFAULT_SUMO_COMMAND_NAME
 
-    def test_create_instance_fails_when_name_exists(self, mocked_instance: mock.MagicMock) -> None:
-        name = inspect.stack()[0][3]
+            SumoInstanceManager._DEFAULT_SUMO_COMMAND_NAME = "command_does_not_exist"
+            with pytest.raises(SumoInstanceManager.SumoExecutableNotFound, match="sumo"):
+                SumoInstanceManager.create_local_tcp_instance(
+                    name,
+                    config=self.FAKE_PATH,
+                    port=port,
+                )
 
-        SumoInstanceManager.create_instance(name, config=self.FAKE_PATH)
-        with pytest.raises(ValueError, match="already exists"):
-            SumoInstanceManager.create_instance(name, config=self.FAKE_PATH)
+            SumoInstanceManager._DEFAULT_SUMO_COMMAND_NAME = default_sumo_command
+            mocked_instance.assert_not_called()
 
-        mocked_instance.assert_called_once()
+        def test_create_local_tcp_instance_fails_when_name_exists(self, mocked_instance: mock.MagicMock) -> None:
+            name = inspect.stack()[0][3]
 
-    def test_get_instance_succeeds(self, mocked_instance: mock.MagicMock) -> None:
-        name = inspect.stack()[0][3]
+            SumoInstanceManager.create_local_tcp_instance(name, config=self.FAKE_PATH)
+            with pytest.raises(ValueError, match="already exists"):
+                SumoInstanceManager.create_local_tcp_instance(name, config=self.FAKE_PATH)
 
-        SumoInstanceManager.create_instance(name, config=self.FAKE_PATH)
-        SumoInstanceManager.get_instance(name)
+            mocked_instance.assert_called_once()
 
-        mocked_instance.assert_called_once()
+        def test_get_instance_succeeds_with_local_tcp(self, mocked_instance: mock.MagicMock) -> None:
+            name = inspect.stack()[0][3]
 
-    def test_get_instance_fails_when_no_instance(self, mocked_instance: mock.MagicMock) -> None:
+            SumoInstanceManager.create_local_tcp_instance(name, config=self.FAKE_PATH)
+            assert isinstance(SumoInstanceManager.get_instance(name), LocalTcpSumoInstance)
+
+            mocked_instance.assert_called_once()
+
+        def test_destroy_instance_succeeds_with_local_tcp(self, mocked_instance: mock.MagicMock) -> None:
+            name = inspect.stack()[0][3]
+
+            SumoInstanceManager.create_local_tcp_instance(name, config=self.FAKE_PATH)
+            SumoInstanceManager.destroy_instance(name)
+
+            mocked_instance.assert_called_once()
+            mocked_instance.return_value.stop.assert_called_once()
+
+    @mock.patch("muve.sumo_server.sumo.manager.LocalLibSumoInstance", autospec=True)
+    class TestLocalLibInstance:
+        """Tests functionality relating to local `libsumo` SUMO instances."""
+
+        FAKE_PATH: Final[pathlib.Path] = pathlib.Path(__file__).absolute()
+
+        def test_create_local_lib_instance_succeeds(self, mocked_instance: mock.MagicMock) -> None:
+            name = inspect.stack()[0][3]
+
+            instance = SumoInstanceManager.create_local_lib_instance(name, config=self.FAKE_PATH)
+
+            assert isinstance(instance, LocalLibSumoInstance)
+            mocked_instance.assert_called_once_with(config=self.FAKE_PATH)
+
+        def test_create_local_lib_instance_fails_when_name_exists(self, mocked_instance: mock.MagicMock) -> None:
+            name = inspect.stack()[0][3]
+
+            SumoInstanceManager.create_local_lib_instance(name, config=self.FAKE_PATH)
+            with pytest.raises(ValueError, match="already exists"):
+                SumoInstanceManager.create_local_lib_instance(name, config=self.FAKE_PATH)
+
+            mocked_instance.assert_called_once()
+
+        def test_get_instance_succeeds_with_local_lib(self, mocked_instance: mock.MagicMock) -> None:
+            name = inspect.stack()[0][3]
+
+            SumoInstanceManager.create_local_lib_instance(name, config=self.FAKE_PATH)
+            assert isinstance(SumoInstanceManager.get_instance(name), LocalLibSumoInstance)
+
+            mocked_instance.assert_called_once()
+
+        def test_destroy_instance_succeeds_with_local_lib(self, mocked_instance: mock.MagicMock) -> None:
+            name = inspect.stack()[0][3]
+
+            SumoInstanceManager.create_local_lib_instance(name, config=self.FAKE_PATH)
+            SumoInstanceManager.destroy_instance(name)
+
+            mocked_instance.assert_called_once()
+            mocked_instance.return_value.stop.assert_called_once()
+
+    def test_get_instance_fails_when_no_instance(self) -> None:
         name = inspect.stack()[0][3]
 
         with pytest.raises(ValueError, match="has not been created"):
             SumoInstanceManager.get_instance(name)
 
-    def test_destroy_instance_succeeds(self, mocked_instance: mock.MagicMock) -> None:
-        name = inspect.stack()[0][3]
-
-        SumoInstanceManager.create_instance(name, config=self.FAKE_PATH)
-        SumoInstanceManager.destroy_instance(name)
-
-        mocked_instance.assert_called_once()
-        mocked_instance.return_value.stop.assert_called_once()
-
-    def test_destroy_instance_fails_when_nonexistent(self, mocked_instance: mock.MagicMock) -> None:
+    def test_destroy_instance_fails_when_nonexistent(self) -> None:
         name = inspect.stack()[0][3]
 
         with pytest.raises(ValueError, match="does not exist"):


### PR DESCRIPTION
We initially planned on working directly with a TCP server to interface with a TraCI server that SUMO brings up. However, SUMO provides an easier way: https://sumo.dlr.de/docs/Libsumo.html.

This introduces a SUMO instance class based on that implementation of TraCI.

Also installs SUMO and libsumo properly in GitHub Actions, which took a while...